### PR TITLE
Issue45

### DIFF
--- a/acros.tex
+++ b/acros.tex
@@ -11,6 +11,7 @@
 \newacronym{ARE}{ARE}{Aircraft Reactor Experiment}
 \newacronym{ARFC}{ARFC}{Advanced Reactors and Fuel Cycles}
 \newacronym{ASME}{ASME}{American Society of Mechanical Engineers}
+\newacronym{ASTRID}{ASTRID}{Advanced Sodium Technological Reactor for Industrial Demonstration}
 \newacronym{ATWS}{ATWS}{Anticipated Transient Without Scram}
 \newacronym{BDBE}{BDBE}{Beyond Design Basis Event}
 \newacronym{BIDS}{BIDS}{Berkeley Institute for Data Science}

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -1,48 +1,43 @@
 
-@techreport{joskow_future_2012,
-	type = {Working {Paper}},
-	title = {The {Future} of {Nuclear} {Power} {After} {Fukushima}},
-	copyright = {An error occurred getting the license - uri.},
-	url = {http://dspace.mit.edu/handle/1721.1/70857},
-	abstract = {This paper analyzes the impact of the Fukushima accident on the future of nuclear
-power around the world. We begin with a discussion of the ‘but for’ baseline and the
-much discussed ‘nuclear renaissance.’ Our pre-Fukushima benchmark for growth in
-nuclear generation in the U.S. and other developed countries is much more modest than
-many bullish forecasts of a big renaissance in new capacity may have suggested. For at
-least the next decade in developed countries, it is composed primarily of life extensions
-for many existing reactors, modest uprates of existing reactors as their licenses are
-extended, and modest levels of new construction. The majority of forecasted new
-construction is centered in China, Russia and the former states of the FSU, India and
-South Korea. In analyzing the impact of Fukushima, we break the effect down into two
-categories: the impact on existing plants, and the impact on the construction of new units.
-In both cases, we argue that the accident at Fukushima will contribute to a reduction in
-future trends in the expansion of nuclear energy, but at this time these effects appear to be
-quite modest at the global level.},
-	language = {en\_US},
-	urldate = {2017-05-17},
-	institution = {MIT CEEPR},
-	author = {Joskow, Paul L. and Parsons, John E.},
-	month = feb,
-	year = {2012},
-	file = {Full Text PDF:/home/dkadkf/Zotero/storage/29IIH4F6/Joskow and Parsons - 2012 - The Future of Nuclear Power After Fukushima.pdf:application/pdf;Snapshot:/home/dkadkf/Zotero/storage/DW6XA46Q/70857.html:text/html}
+@article{huff_fundamental_2016,
+	title = {Fundamental concepts in the {Cyclus} nuclear fuel cycle simulation framework},
+	volume = {94},
+	issn = {0965-9978},
+	url = {http://www.sciencedirect.com/science/article/pii/S0965997816300229},
+	doi = {10.1016/j.advengsoft.2016.01.014},
+	abstract = {As nuclear power expands, technical, economic, political, and environmental analyses of nuclear fuel cycles by simulators increase in importance. To date, however, current tools are often fleet-based rather than discrete and restrictively licensed rather than open source. Each of these choices presents a challenge to modeling fidelity, generality, efficiency, robustness, and scientific transparency. The Cyclus nuclear fuel cycle simulator framework and its modeling ecosystem incorporate modern insights from simulation science and software architecture to solve these problems so that challenges in nuclear fuel cycle analysis can be better addressed. A summary of the Cyclus fuel cycle simulator framework and its modeling ecosystem are presented. Additionally, the implementation of each is discussed in the context of motivating challenges in nuclear fuel cycle simulation. Finally, the current capabilities of Cyclus are demonstrated for both open and closed fuel cycles.},
+	urldate = {2016-02-12},
+	journal = {Advances in Engineering Software},
+	author = {Huff, Kathryn D. and Gidden, Matthew J. and Carlsen, Robert W. and Flanagan, Robert R. and McGarry, Meghan B. and Opotowsky, Arrielle C. and Schneider, Erich A. and Scopatz, Anthony M. and Wilson, Paul P. H.},
+	month = apr,
+	year = {2016},
+	keywords = {agent based modeling, agent based modeling, and Science, Computer Science - Computational Engineering, Computer Science - Computational Engineering, Finance, and Science, Computer Science - Mathematical Software, Computer Science - Mathematical Software, Computer Science - Multiagent Systems, Computer Science - Multiagent Systems, Computer Science - Software Engineering, Computer Science - Software Engineering, D.2.4, D.2.4, D.2.13, D.2.13, Finance, I.6.7, I.6.7, I.6.8, I.6.8, Nuclear Engineering, Nuclear Engineering, Nuclear fuel cycle, Nuclear Fuel Cycle, Object orientation, Object orientation, Simulation, Simulation, Systems analysis, Systems Analysis},
+	pages = {46--59},
+	file = {arXiv\:1509.03604 PDF:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/4FI3T63Q/Huff et al. - 2015 - Fundamental Concepts in the Cyclus Fuel Cycle Simu.pdf:application/pdf;arXiv\:1509.03604 PDF:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/F9KVM9DZ/Huff et al. - 2015 - Fundamental Concepts in the Cyclus Fuel Cycle Simu.pdf:application/pdf;arXiv.org Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/WQVTXAN2/1509.html:text/html;arXiv.org Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/HXSDS7VW/1509.html:text/html;fundamentals.pdf:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/BRJECDWC/fundamentals.pdf:application/pdf;fundamentals.pdf:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/C6G4NQJH/fundamentals.pdf:application/pdf;ScienceDirect Full Text PDF:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/E7DK64AA/Huff et al. - 2016 - Fundamental concepts in the Cyclus nuclear fuel cy.pdf:application/pdf;ScienceDirect Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/63CHUQ54/login.html:text/html;ScienceDirect Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/EVBNKXMA/S0965997816300229.html:text/html;ScienceDirect Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/JCCZAZB3/S0965997816300229.html:text/html}
 }
 
-@phdthesis{fabbris_optimisation_2014,
-	type = {phdthesis},
-	title = {Optimisation multi-physique et multi-critère des coeurs de {RNR}-{Na} : application au concept {CFV}},
-	shorttitle = {Optimisation multi-physique et multi-critère des coeurs de {RNR}-{Na}},
-	url = {https://tel.archives-ouvertes.fr/tel-01133491/document},
-	abstract = {La conception du coeur d’un réacteur nucléaire est fortement multidisciplinaire (neutronique, thermo-hydraulique, thermomécanique du combustible, physique du cycle, etc.). Le problème est aussi de type multi-objectif (plusieurs performances) à grand nombre de dimensions (plusieurs dizaines de paramètres de conception).Les codes de calculs déterministes utilisés traditionnellement pour la caractérisation des coeurs demandant d’importantes ressources informatiques, l’approche de conception classique rend difficile l’exploration et l’optimisation de nouveaux concepts innovants. Afin de pallier ces difficultés, une nouvelle méthodologie a été développée lors de ces travaux de thèse. Ces travaux sont basés sur la mise en oeuvre et la validation de schémas de calculs neutronique et thermo-hydraulique pour disposer d’un outil de caractérisation d’un coeur de réacteur à neutrons rapides à caloporteur sodium tant du point de vue des performances neutroniques que de son comportement en transitoires accidentels.La méthodologie mise en oeuvre s’appuie sur la construction de modèles de substitution (ou métamodèles) aptes à remplacer la chaîne de calcul neutronique et thermo-hydraulique. Des méthodes mathématiques avancées pour la planification d’expériences, la construction et la validation des métamodèles permettent de remplacer cette chaîne de calcul par des modèles de régression au pouvoir de prédiction élevé.La méthode est appliquée à un concept innovant de coeur à Faible coefficient de Vidange sur un très large domaine d’étude, et à son comportement lors de transitoires thermo-hydrauliques non protégés pouvant amener à des situations incidentelles, voire accidentelles. Des analyses globales de sensibilité permettent d’identifier les paramètres de conception influents sur la conception du coeur et son comportement en transitoire. Des optimisations multicritères conduisent à des nouvelles configurations dont les performances sont parfois significativement améliorées. La validation des résultats produits au cours de ces travaux de thèse démontre la pertinence de la méthode au stade de la préconception d’un coeur de réacteur à neutrons rapides refroidi au sodium.},
-	language = {fr},
-	urldate = {2017-07-21},
-	school = {Université de Grenoble},
-	author = {Fabbris, Olivier},
+@techreport{wilson_adoption_2009,
+	title = {The {Adoption} of {Advanced} {Fuel} {Cycle} {Technology} {Under} a {Single} {Repository} {Policy}},
+	institution = {University of Wisconsin -- Madison},
+	author = {Wilson, P.},
+	year = {2009}
+}
+
+@article{brown_identification_2016,
+	title = {Identification of fuel cycle simulator functionalities for analysis of transition to a new fuel cycle},
+	volume = {96},
+	issn = {0306-4549},
+	url = {http://www.sciencedirect.com/science/article/pii/S0306454916303383},
+	doi = {10.1016/j.anucene.2016.05.027},
+	abstract = {Dynamic fuel cycle simulation tools are intended to model holistic transient nuclear fuel cycle scenarios. As with all simulation tools, fuel cycle simulators require verification through unit tests, benchmark cases, and integral tests. Model validation is a vital aspect, as well. Although comparative studies have been performed, there is no comprehensive unit test and benchmark library for fuel cycle simulator tools. The objective of this paper is to identify some of the {\textquotedblleft}must test{\textquotedblright} functionalities of a fuel cycle simulator tool within the context of specific problems of interest to the Fuel Cycle Options Campaign within the U.S. Department of Energy{\textquoteright}s Office of Nuclear Energy (DOE-NE). This paper identifies the features needed to cover the range of promising fuel cycle options identified in the DOE-NE Fuel Cycle Evaluation and Screening and categorizes these features to facilitate prioritization. Features are categorized as essential functions, integrating features, and exemplary capabilities. A library of unit tests applicable to each of the essential functions should be developed as future work. An international dialog on the functionalities and standard test methods for fuel cycle simulator tools is encouraged.},
+	urldate = {2016-09-23},
+	journal = {Annals of Nuclear Energy},
+	author = {Brown, Nicholas R. and Carlsen, Brett W. and Dixon, Brent W. and Feng, Bo and Greenberg, Harris R. and Hays, Ross D. and Passerini, Stefano and Todosow, Michael and Worrall, Andrew},
 	month = oct,
-	year = {2014},
-	annote = {85 - geometry
-91 - initial fuel
- },
-	file = {Full Text PDF:/home/dkadkf/Zotero/storage/AI9FANBF/Fabbris - 2014 - Optimisation multi-physique et multi-critère des c.pdf:application/pdf;Snapshot:/home/dkadkf/Zotero/storage/54B5PP4P/tel-01133491.html:text/html}
+	year = {2016},
+	keywords = {Fuel cycle simulator, Transition analysis, Unit tests},
+	pages = {88--95},
+	file = {ScienceDirect Full Text PDF:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/9H5GZ7QA/Brown et al. - 2016 - Identification of fuel cycle simulator functionali.pdf:application/pdf;ScienceDirect Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/NFQC7CXG/S0306454916303383.html:text/html;ScienceDirect Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/Z6WQH4Q4/S0306454916303383.html:text/html}
 }
 
 @techreport{boucher_benchmark_2012,
@@ -52,29 +47,77 @@ quite modest at the global level.},
 	author = {Boucher, L.},
 	month = jun,
 	year = {2012},
-	file = {nsc-wpfc-doc2012-16.pdf:/home/dkadkf/Zotero/storage/3SSZVRG4/nsc-wpfc-doc2012-16.pdf:application/pdf}
+	file = {nsc-wpfc-doc2012-16.pdf:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/3SSZVRG4/nsc-wpfc-doc2012-16.pdf:application/pdf}
 }
 
-@inproceedings{hugelmann_melox_1999,
-	title = {{MELOX} fuel fabrication plant: operational feedback and future prospects},
-	volume = {3},
-	shorttitle = {{MELOX} fuel fabrication plant},
-	url = {http://www.iaea.org/inis/collection/NCLCollectionStore/_Public/31/062/31062323.pdf#page=110},
-	urldate = {2017-05-03},
-	booktitle = {{MOX} {Fuel} {Cycle} {Technologies} for {Medium} and {Long} {Term} {Deployment} ({Proc}. {Symp}. {Vienna}, 1999), {C}\&{S} {Papers} {Series} {No}},
-	author = {Hugelmann, D. and Greneche, D.},
-	year = {1999},
-	pages = {102--108},
-	file = {[PDF] iaea.org:/home/dkadkf/Zotero/storage/II69N986/Hugelmann and Greneche - 1999 - MELOX fuel fabrication plant operational feedback.pdf:application/pdf}
+@article{martin_symbiotic_2017,
+	title = {Symbiotic equilibrium between {Sodium} {Fast} {Reactors} and {Pressurized} {Water} {Reactors} supplied with {MOX} fuel},
+	volume = {103},
+	issn = {0306-4549},
+	url = {http://www.sciencedirect.com/science/article/pii/S0306454916308076},
+	doi = {10.1016/j.anucene.2017.01.041},
+	abstract = {The symbiotic equilibrium between 1.51 GWe breeder SFR (Sodium Fast Reactors) and 1.6 GWe EPR{\texttrademark} (European Pressurized water Reactors) is studied. EPR{\texttrademark} are only supplied with MOX (Mixed OXide) fuel to avoid the use of natural uranium. The equilibrium is studied by considering the flows of plutonium. Its isotopic composition is here described by a single real number referred to as the Pu grade. Plutonium flows through both reactor types are characterized by using linear functions of the Pu grade in new fuels. These functions have been determined by fitting data from a former scenario study carried out with the COSI6 simulation software.
+Two different reprocessing strategies are considered. With joint reprocessing of all spent fuels, total and fissile plutonium flows balance for a unique fraction x of EPR{\texttrademark} in the fleet, equal to 0.2547. This x value is consistent with the results reported in the former scenario study mentioned above. When EPR{\texttrademark} spent fuels are used in priority to supply SFR (distinct reprocessing), x reaches 0.2582 at most. COSI6 simulations have been performed to further assess these results. The EPR{\texttrademark} fraction in the fleet at symbiotic equilibrium barely depends on the applied reprocessing strategy, so that the more flexible joint reprocessing constitutes the reference option in that case.},
+	urldate = {2017-02-16},
+	journal = {Annals of Nuclear Energy},
+	author = {Martin, G. and Coquelet-Pascal, C.},
+	month = may,
+	year = {2017},
+	keywords = {EPR{\texttrademark}, FAST REACTORS, Fuel reprocessing, Nuclear energy, plutonium, SFR, Symbiotic nuclear systems, Thermal reactors},
+	pages = {356--362},
+	file = {ScienceDirect Full Text PDF:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/4D8VC2KI/Martin and Coquelet-Pascal - 2017 - Symbiotic equilibrium between Sodium Fast Reactors.pdf:application/pdf;ScienceDirect Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/VPCQBPZW/S0306454916308076.html:text/html}
 }
 
-@book{schneider_spent_2008,
-	title = {Spent nuclear fuel reprocessing in {France}},
-	url = {http://www.psr.org/nuclear-bailout/resources/spent-nuclear-fuel.pdf},
-	author = {Schneider, Mycle and Marignac, Yves},
-	year = {2008},
-	annote = {La Hague - 1100 tons/year
- }
+@article{freynet_multiobjective_2016,
+	title = {Multiobjective optimization for nuclear fleet evolution scenarios using {COSI}},
+	volume = {2},
+	url = {http://epjn.epj.org/articles/epjn/abs/2016/01/epjn150066/epjn150066.html},
+	urldate = {2017-02-17},
+	journal = {EPJ Nuclear Sciences \& Technologies},
+	author = {Freynet, David and Coquelet-Pascal, Christine and Eschbach, Romain and Krivtchik, Guillaume and Merle-Lucotte, Elsa},
+	year = {2016},
+	pages = {9},
+	file = {[HTML] epj-n.org:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/AVP329PE/epjn150066.html:text/html;Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/HIBGZJTC/epjn150066.html:text/html}
+}
+
+@article{wigeland_nuclear_2014,
+	title = {Nuclear {Fuel} {Cycle} {Evaluation} and {Screening}{\textendash}{Final} {Report}},
+	url = {https://fuelcycleevaluation.inl.gov/Shared%20Documents/ES%20Main%20Report.pdf},
+	urldate = {2017-03-29},
+	author = {Wigeland, R and Taiwo, T and Ludewig, H and Todosow, M and Halsey, W and Gehin, J and Jubin, R and Buelt, J and Stockinger, S and Jenni, K and Oakley, B},
+	year = {2014},
+	file = {ES Main Report.pdf:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/WEVPB9EQ/ES Main Report.pdf:application/pdf}
+}
+
+@techreport{oecd_spent_2011,
+	title = {Spent {Nuclear} {Fuel} {Asssay} {Data} for {Isotopic} {Validation}},
+	url = {https://www.oecd-nea.org/science/wpncs/ADSNF/SOAR_final.pdf},
+	abstract = {Management of spent fuel from commercial nuclear reactors is a key issue for many NEA
+member countries. As interim storage facilities in many countries reach their design capacities,
+the need to optimise spent fuel storage management is becoming an increasingly important
+issue to managing fuel cycle costs while reducing associated risks. In nuclear criticality safety
+studies involving spent fuel, burn-up credit is being pursued and has been implemented in many
+countries as a means of more accurately and realistically determining the system reactivity by
+taking into account a decrease in the reactivity of spent fuel during irradiation. Implementation
+of burn-up credit has gained in world-wide interest during the last 20 years and it represents one
+of the most technically challenging issues in nuclear criticality safety. To address these challenges
+and help co-ordinate activities in NEA member countries, the Working Party on Nuclear
+Criticality Safety (WPNCS) of the OECD/NEA Nuclear Science Committee (NSC) has organised the
+Expert Group on Burn-up Credit Criticality (EGBUC). The decision of many countries to advance
+burn-up credit as part of their criticality safety licensing strategy has heightened interest in
+measurement data needed to validate code calculations for a burn-up credit methodology.},
+	institution = {Nuclear Energy Agency},
+	author = {OECD},
+	year = {2011}
+}
+
+@techreport{hermann_validation_1995,
+	title = {Validation of the {SCALE} system for {PWR} spent fuel isotopic composition analyses},
+	url = {http://www.osti.gov/scitech/biblio/57886},
+	urldate = {2017-04-03},
+	institution = {Oak Ridge National Lab., TN (United States)},
+	author = {Hermann, O. W. and Bowman, S. M. and Parks, C. V. and Brady, M. C.},
+	year = {1995}
 }
 
 @techreport{iaea_management_2007,
@@ -118,63 +161,148 @@ reprocessed uranium.},
 	author = {World Nuclear Association},
 	month = feb,
 	year = {2017},
-	file = {Nuclear Power in the European Union - World Nuclear Association:/home/dkadkf/Zotero/storage/VG9QDBRU/european-union.html:text/html}
+	file = {Nuclear Power in the European Union - World Nuclear Association:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/VG9QDBRU/european-union.html:text/html}
 }
 
-@techreport{hermann_validation_1995,
-	title = {Validation of the {SCALE} system for {PWR} spent fuel isotopic composition analyses},
-	url = {http://www.osti.gov/scitech/biblio/57886},
-	urldate = {2017-04-03},
-	institution = {Oak Ridge National Lab., TN (United States)},
-	author = {Hermann, O. W. and Bowman, S. M. and Parks, C. V. and Brady, M. C.},
-	year = {1995}
+@book{schneider_spent_2008,
+	title = {Spent nuclear fuel reprocessing in {France}},
+	url = {http://www.psr.org/nuclear-bailout/resources/spent-nuclear-fuel.pdf},
+	author = {Schneider, Mycle and Marignac, Yves},
+	year = {2008}
 }
 
-@techreport{oecd_spent_2011,
-	title = {Spent {Nuclear} {Fuel} {Asssay} {Data} for {Isotopic} {Validation}},
-	url = {https://www.oecd-nea.org/science/wpncs/ADSNF/SOAR_final.pdf},
-	abstract = {Management of spent fuel from commercial nuclear reactors is a key issue for many NEA
-member countries. As interim storage facilities in many countries reach their design capacities,
-the need to optimise spent fuel storage management is becoming an increasingly important
-issue to managing fuel cycle costs while reducing associated risks. In nuclear criticality safety
-studies involving spent fuel, burn-up credit is being pursued and has been implemented in many
-countries as a means of more accurately and realistically determining the system reactivity by
-taking into account a decrease in the reactivity of spent fuel during irradiation. Implementation
-of burn-up credit has gained in world-wide interest during the last 20 years and it represents one
-of the most technically challenging issues in nuclear criticality safety. To address these challenges
-and help co-ordinate activities in NEA member countries, the Working Party on Nuclear
-Criticality Safety (WPNCS) of the OECD/NEA Nuclear Science Committee (NSC) has organised the
-Expert Group on Burn-up Credit Criticality (EGBUC). The decision of many countries to advance
-burn-up credit as part of their criticality safety licensing strategy has heightened interest in
-measurement data needed to validate code calculations for a burn-up credit methodology.},
-	institution = {Nuclear Energy Agency},
-	author = {OECD},
-	year = {2011}
+@inproceedings{hugelmann_melox_1999,
+	title = {{MELOX} fuel fabrication plant: operational feedback and future prospects},
+	volume = {3},
+	shorttitle = {{MELOX} fuel fabrication plant},
+	url = {http://www.iaea.org/inis/collection/NCLCollectionStore/_Public/31/062/31062323.pdf#page=110},
+	urldate = {2017-05-03},
+	booktitle = {{MOX} {Fuel} {Cycle} {Technologies} for {Medium} and {Long} {Term} {Deployment} ({Proc}. {Symp}. {Vienna}, 1999), {C}\&{S} {Papers} {Series} {No}},
+	author = {Hugelmann, D. and Greneche, D.},
+	year = {1999},
+	pages = {102--108},
+	file = {[PDF] iaea.org:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/II69N986/Hugelmann and Greneche - 1999 - MELOX fuel fabrication plant operational feedback.pdf:application/pdf}
 }
 
-@article{wigeland_nuclear_2014,
-	title = {Nuclear {Fuel} {Cycle} {Evaluation} and {Screening}–{Final} {Report}},
-	url = {https://fuelcycleevaluation.inl.gov/Shared%20Documents/ES%20Main%20Report.pdf},
-	urldate = {2017-03-29},
-	author = {Wigeland, R and Taiwo, T and Ludewig, H and Todosow, M and Halsey, W and Gehin, J and Jubin, R and Buelt, J and Stockinger, S and Jenni, K and Oakley, B},
-	year = {2014},
-	file = {ES Main Report.pdf:/home/dkadkf/Zotero/storage/WEVPB9EQ/ES Main Report.pdf:application/pdf}
+@article{lamarsh_introduction_1983,
+	title = {Introduction to nuclear engineering},
+	url = {https://inis.iaea.org/search/search.aspx?orig_q=RN:17073185},
+	urldate = {2017-05-11},
+	author = {Lamarsh, John R.},
+	year = {1983},
+	file = {Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/SZH27EZ6/search.html:text/html}
 }
 
-@techreport{piet_implications_2010,
-	title = {Implications of {Fast} {Reactor} {Transuranic} {Conversion} {Ratio}},
-	url = {https://www.researchgate.net/profile/Steve_Piet/publication/255218036_Implications_of_Fast_Reactor_Transuranic_Conversion_Ratio/links/54f87b470cf2ccffe9df3b55/Implications-of-Fast-Reactor-Transuranic-Conversion-Ratio.pdf},
-	institution = {Idaho National Laboratory (INL)},
-	author = {Piet, Steven J. and Hoffman, Edward A. and Bays, Samuel E.},
-	year = {2010},
-	file = {[PDF] researchgate.net:/home/dkadkf/Zotero/storage/WSSD6JHQ/Piet et al. - 2010 - Implications of Fast Reactor Transuranic Conversio.pdf:application/pdf}
+@book{hatch_politics_2015,
+	title = {Politics and {Nuclear} {Power}: {Energy} {Policy} in {Western} {Europe}},
+	isbn = {978-0-8131-6307-9},
+	shorttitle = {Politics and {Nuclear} {Power}},
+	abstract = {With the dramatic changes OPEC precipitated in the structure of world energy markets during the 1970s, energy became a central concern to policymakers throughout the industrialized West. This book ex-amines the responses of public officials in three leading European nations -- the Federal Republic of Germany, France, and the Netherlands -- to the energy crisis. As the study shows, the proposed energy programs in the three countries shared remarkable similarities; yet the policy outcomes were very different. To explain why, Michael T. Hatch goes beyond the specific content of government energy policy to include an analysis of the policymaking process itself.At the heart of the study is an exploration of the various dimensions of nuclear policy in West Germany. The political consensus on nuclear power that prevailed in the initial years following the energy crisis disintegrated as antinuclear "citizens' initiatives," the courts, and trade unions, as well as the traditional political parties, entered the policymaking process. Subsequent government efforts to resolve the political stalemate over nuclear power foundered in a morass of domestic electoral politics and an international debate over nuclear proliferation.Extending the analysis to comparisons with French and Dutch nuclear strategies, Hatch argues that the critical factor in determining nuclear policy was the manner in which the political system structured the nuclear debate. In contrast to West Germany, where the electoral and parliamentary systems enhanced the influence of the antinuclear "Greens," the electoral system and constellation of political parties in France served to dissipate the influence of the antinuclear forces. Thus in France the nuclear program en-countered few impediments. In the Netherlands, as in West Germany, government policy was paralyzed in the face of antinuclear sentiment across a broad spectrum of Dutch society.Hatch has provided here not only a useful examination of the development of energy policy in western Europe but also a case study of the close interplay between policy and politics.},
+	language = {en},
+	publisher = {University Press of Kentucky},
+	author = {Hatch, Michael T.},
+	month = jan,
+	year = {2015},
+	note = {Google-Books-ID: TrwfBgAAQBAJ},
+	keywords = {History / Europe / Western, Political Science / Public Policy / Science \& Technology Policy, Technology \& Engineering / Power Resources / Nuclear}
 }
 
-@article{martinez-val_pateros_2009,
-	title = {{PATEROS} {P}\&{T} {Roadmap} proposal for advanced fuel cycles leading to a sustainable nuclear energy: syntheses report},
-	shorttitle = {{PATEROS} {P}\&{T} {Roadmap} proposal for advanced fuel cycles leading to a sustainable nuclear energy},
-	author = {Martinez-Val, J.},
-	year = {2009}
+@techreport{joskow_future_2012,
+	type = {Working {Paper}},
+	title = {The {Future} of {Nuclear} {Power} {After} {Fukushima}},
+	copyright = {An error occurred getting the license - uri.},
+	url = {http://dspace.mit.edu/handle/1721.1/70857},
+	abstract = {This paper analyzes the impact of the Fukushima accident on the future of nuclear
+power around the world. We begin with a discussion of the {\textquoteleft}but for{\textquoteright} baseline and the
+much discussed {\textquoteleft}nuclear renaissance.{\textquoteright} Our pre-Fukushima benchmark for growth in
+nuclear generation in the U.S. and other developed countries is much more modest than
+many bullish forecasts of a big renaissance in new capacity may have suggested. For at
+least the next decade in developed countries, it is composed primarily of life extensions
+for many existing reactors, modest uprates of existing reactors as their licenses are
+extended, and modest levels of new construction. The majority of forecasted new
+construction is centered in China, Russia and the former states of the FSU, India and
+South Korea. In analyzing the impact of Fukushima, we break the effect down into two
+categories: the impact on existing plants, and the impact on the construction of new units.
+In both cases, we argue that the accident at Fukushima will contribute to a reduction in
+future trends in the expansion of nuclear energy, but at this time these effects appear to be
+quite modest at the global level.},
+	language = {en\_US},
+	urldate = {2017-05-17},
+	institution = {MIT CEEPR},
+	author = {Joskow, Paul L. and Parsons, John E.},
+	month = feb,
+	year = {2012},
+	file = {Full Text PDF:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/29IIH4F6/Joskow and Parsons - 2012 - The Future of Nuclear Power After Fukushima.pdf:application/pdf;Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/DW6XA46Q/70857.html:text/html}
+}
+
+@article{varaine_pre-conceptual_2012,
+	title = {Pre-conceptual design study of {ASTRID} core},
+	url = {https://www.researchgate.net/profile/Frederic_Varaine/publication/282657288_Pre-conceptual_design_study_of_ASTRID_core/links/56166d1908ae37cfe4090bb7.pdf},
+	abstract = {In the framework of the ASTRID project at CEA, core design studies are performed at CEA with the AREVA and EDF support. At the stage of the project, pre-conceptual design studies are conducted in accordance with GEN IV reactors criteria, in particularly for safety improvements. An improved safety for a sodium cooled reactor requires revisiting many aspects of the design and is a rather lengthy process in current design approach. Two types of cores are under evaluation, one classical derivated from the SFR V2B and one more challenging called CFV (low void effect core) with a large gain on the sodium void effect. The SFR V2b core have the following specifications : a very low burn-up reactivity swing (due to a small cycle reactivity loss) and a reduced sodium void effect with regard to past designs such as the EFR (around 2\$ minus). Its performances are an average burn-up of 100 GWd/t, and an internal conversion ratio equal to one given a very good behavior of this core during a control rod withdrawal transient). The CFV with its specific design offers a negative sodium void worth while maintaining core performances. In accordance of ASTRID needs for demonstration those cores are 1500 MWth power (600 MWe). This paper will focus on the CFV pre-conceptual design of the core and S/A, and the performances in terms of safety will be evaluated on different transient scenario like ULOF, in order to assess its intrinsic behavior compared to a more classical design like V2B core. The gap in term of margin to a severe accident due to a loss of flow initiator underlines the potential capability of this type of core to enhance prevention of severe accident in accordance to safety demonstration. 
+
+Pre-conceptual design study of ASTRID core (PDF Download Available). Available from: https://www.researchgate.net/publication/282657288\_Pre-conceptual\_design\_study\_of\_ASTRID\_core [accessed Aug 31, 2017].},
+	urldate = {2017-05-19},
+	author = {Varaine, Frederic and Chenaud, Marie-Sophie and Marsault, Philippe and Bernardin, Bruno and Conti, Alain and Sciora, Pierre and Venard, Christophe and Fontaine, Bruno and Martin, Laurent and Mignot, Gerard},
+	month = jun,
+	year = {2012},
+	file = {[PDF] researchgate.net:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/2B4SNXP4/MARSAULT{\textendash}Marie-Sophie et al. - Pre-conceptual design study of ASTRID core.pdf:application/pdf}
+}
+
+@article{sutharshan_ap1000tm_2011,
+	series = {Asian {Nuclear} {Prospects} 2010},
+	title = {The {AP}1000TM {Reactor}: {Passive} {Safety} and {Modular} {Design}},
+	volume = {7},
+	issn = {1876-6102},
+	shorttitle = {The {AP}1000TM {Reactor}},
+	url = {http://www.sciencedirect.com/science/article/pii/S1876610211015475},
+	doi = {10.1016/j.egypro.2011.06.038},
+	abstract = {Our world is ever growing, there will be higher demands on electricity, and fossil fuels cannot satisfy this demand without further harming the environment. Likewise, renewable energy sources such as solar and winds are still in their infancy and, when used alone, are not realistic solutions to meet this demand. Westinghouse Electric Company is ready to address higher electricity demand with the only Generation III+reactor to receive Design Certification from the United States Nuclear Regulatory Commission, the AP1000{\texttrademark} pressurized water reactor (PWR). Westinghouse Electric Company once again sets a new industry standard with the AP1000{\texttrademark} reactor. The AP1000{\texttrademark} is a two-loopPressurized Water Reactor (PWR) with passive safety features and extensive plant simplifications that enhance its construction, operation, maintenance and safety. The paper discusses the unique design features of AP 1000.},
+	urldate = {2017-05-12},
+	journal = {Energy Procedia},
+	author = {Sutharshan, Balendra and Mutyala, Meena and Vijuk, Ronald P and Mishra, Alok},
+	month = jan,
+	year = {2011},
+	keywords = {core operating parameters, Generation III+ reactor, modular design, passive safety, probabilistic risk assessment, PWR},
+	pages = {293--302},
+	file = {ScienceDirect Full Text PDF:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/2D66N8K4/Sutharshan et al. - 2011 - The AP1000TM Reactor Passive Safety and Modular D.pdf:application/pdf;ScienceDirect Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/E87IC8RM/S1876610211015475.html:text/html}
+}
+
+@techreport{cne2_reports_2015,
+	title = {Reports of the {CNE}2},
+	url = {https://www.cne2.fr/index.php/en/cne-2-2007-to-this-day},
+	abstract = {According to the provisions of the 2006 act, the long-term management of high and intermediatelevel
+waste involves two related components: the partitioning-transmutation of actinides found in the
+spent fuel of future nuclear reactors and the geological disposal of long-lived high and intermediatelevel
+waste (LLHLW \& LLILW) in accordance with the principle of reversibility. In addition, facilities
+in the front-end and back-end of the nuclear fuel cycle and the dismantling of decommissioned
+facilities produce long-lived low-level waste (LLLLW), very low-level waste (VLLW) and waste
+with augmented natural radioactivity. The LLLLW pose different management problems due to the
+very large quantities produced. Short-lived low and intermediate-level waste is stored at the Aube
+storage centre (centre de stockage de l{\textquoteright}Aube {\textendash} CSA)},
+	language = {English},
+	urldate = {2017-06-24},
+	institution = {Commission Nationae D'Evaluation},
+	author = {CNE2},
+	month = jun,
+	year = {2015},
+	pages = {120},
+	file = {CNE2 - Reports of the CNE2 - 2007 to this day:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/9WF2G3QN/cne-2-2007-to-this-day.html:text/html}
+}
+
+@article{salvatores_nuclear_2005,
+	title = {Nuclear fuel cycle strategies including {Partitioning} and {Transmutation}},
+	volume = {235},
+	issn = {0029-5493},
+	url = {http://www.sciencedirect.com/science/article/pii/S0029549304003759},
+	doi = {10.1016/j.nucengdes.2004.10.009},
+	abstract = {The widespread concern about radioactive waste management has promoted interest during the last decade for the potential role of Partitioning and Transmutation strategies, in order to alleviate the burden on future deep geological repositories. The physics of transmutation allows to point-out preferential approaches, e.g., based on the use of a fast neutron spectrum. The practical implementation of Partitioning and Transmutation implies the development of sophisticated technologies and can be more realistic if seen in a regional context. Some examples will be given to illustrate the {\textquotedblleft}regional{\textquotedblright} approach, and some considerations will be made on the use of Accelerator Driven Systems (ADS), in the frame of a progressive strategy from present nuclear power fleets to future systems, as studied, e.g., in the frame of the GENERATION-IV initiative.},
+	number = {7},
+	journal = {Nuclear Engineering and Design},
+	author = {Salvatores, M.},
+	month = mar,
+	year = {2005},
+	pages = {805--816},
+	file = {ScienceDirect Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/3PMMTCTG/S0029549304003759.html:text/html}
 }
 
 @misc{fazio_study_2013,
@@ -198,67 +326,20 @@ nuclear energy phase out option.},
 	author = {Fazio, C},
 	month = oct,
 	year = {2013},
-	annote = {Regional (European) scenario of partitioning and transmutation to lessen SNF load},
-	file = {Snapshot:/home/dkadkf/Zotero/storage/2STTNZDS/264479296_Study_on_partitioning_and_transmutation_as_a_possible_option_for_spent_fuel_management.pdf:application/pdf}
+	file = {Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/2STTNZDS/264479296_Study_on_partitioning_and_transmutation_as_a_possible_option_for_spent_fuel_management.pdf:application/pdf}
 }
 
-@article{gabrielli_astrid-like_2015,
-	series = {The {Fourth} {International} {Symposium} on {Innovative} {Nuclear} {Energy} {Systems}, {INES}-4},
-	title = {{ASTRID}-like {Fast} {Reactor} {Cores} for {Burning} {Plutonium} and {Minor} {Actinides}},
-	volume = {71},
-	issn = {1876-6102},
-	url = {http://www.sciencedirect.com/science/article/pii/S1876610214026927},
-	doi = {10.1016/j.egypro.2014.11.863},
-	abstract = {A reduction of nuclear waste by transmutation of trans-uranium elements (TRUs), such as Pu and Minor Actinides (MAs) contained in Spent Nuclear Fuel (SNF), is a goal for future reactors. In general, countries with on-going nuclear scenarios would profit from MA mass stabilization, while transmutation of Pu and MAs from SNF could be desired in countries in nuclear phase-out. Both missions can be accomplished by employing fast reactors loaded with fuels containing different amounts of Pu and MAs in a closed (or partially closed) fuel cycle. In this paper, two 1200 MWth sodium-cooled fast reactor cores, based on the French ASTRID design, are proposed for burning TRUs (phase-out option) or only MAs (on-going option). Main attention is focused on the safety and on the transmutation performance. The coolant void effect, in the region including the core and the plenum above and the Doppler constant of both systems are negative also with irradiated fuel. The conversion ratios (CR) of the Pu and MA burners are in the ranges from 0.6 to 0.7 and from 0.5 to 0.6, respectively. These results show a large safety and transmutation potential of ASTRID type reactors.},
-	journal = {Energy Procedia},
-	author = {Gabrielli, Fabrizio and Rineiski, Andrei and Vezzoni, Barbara and Maschek, Werner and Fazio, Concetta and Salvatores, Massimo},
-	month = may,
-	year = {2015},
-	keywords = {Nuclear fuel cycle, Nuclear reactor safety, Sodium fast reactors, Transmutation},
-	pages = {130--139},
-	file = {ScienceDirect Full Text PDF:/home/dkadkf/Zotero/storage/2APV2MPJ/Gabrielli et al. - 2015 - ASTRID-like Fast Reactor Cores for Burning Plutoni.pdf:application/pdf;ScienceDirect Snapshot:/home/dkadkf/Zotero/storage/I78CKW34/S1876610214026927.html:text/html}
-}
-
-@techreport{cne2_reports_2015,
-	title = {Reports of the {CNE}2},
-	url = {https://www.cne2.fr/index.php/en/cne-2-2007-to-this-day},
-	abstract = {According to the provisions of the 2006 act, the long-term management of high and intermediatelevel
-waste involves two related components: the partitioning-transmutation of actinides found in the
-spent fuel of future nuclear reactors and the geological disposal of long-lived high and intermediatelevel
-waste (LLHLW \& LLILW) in accordance with the principle of reversibility. In addition, facilities
-in the front-end and back-end of the nuclear fuel cycle and the dismantling of decommissioned
-facilities produce long-lived low-level waste (LLLLW), very low-level waste (VLLW) and waste
-with augmented natural radioactivity. The LLLLW pose different management problems due to the
-very large quantities produced. Short-lived low and intermediate-level waste is stored at the Aube
-storage centre (centre de stockage de l’Aube – CSA)},
-	language = {English},
-	urldate = {2017-06-24},
-	institution = {Commission Nationae D'Evaluation},
-	author = {CNE2},
-	month = jun,
-	year = {2015},
-	pages = {120},
-	file = {CNE2 - Reports of the CNE2 - 2007 to this day:/home/dkadkf/Zotero/storage/9WF2G3QN/cne-2-2007-to-this-day.html:text/html}
-}
-
-@article{freynet_multiobjective_2016,
-	title = {Multiobjective optimization for nuclear fleet evolution scenarios using {COSI}},
-	volume = {2},
-	url = {http://epjn.epj.org/articles/epjn/abs/2016/01/epjn150066/epjn150066.html},
-	journal = {EPJ Nuclear Sciences \& Technologies},
-	author = {Freynet, David and Coquelet-Pascal, Christine and Eschbach, Romain and Krivtchik, Guillaume and Merle-Lucotte, Elsa},
-	year = {2016},
-	pages = {9},
-	file = {epjn150066.pdf:/home/dkadkf/Zotero/storage/HA6HH8VJ/epjn150066.pdf:application/pdf;[HTML] epj-n.org:/home/dkadkf/Zotero/storage/ZHNXV2WH/epjn150066.html:text/html;Snapshot:/home/dkadkf/Zotero/storage/8URTHTBQ/epjn150066.html:text/html}
-}
-
-@article{coquelet-pascal_comparison_nodate,
-	title = {Comparison of different scenarios for the deployment of fast reactors in {France}. {Results} obtained with {COSI}},
-	url = {http://inis.iaea.org/Search/search.aspx?orig_q=RN:44008962},
-	language = {English},
-	urldate = {2017-06-17},
-	author = {Coquelet-Pascal, Christine and Meyer, Maryan and Girieud, Richard},
-	file = {Snapshot:/home/dkadkf/Zotero/storage/USKER87I/search.html:text/html}
+@inproceedings{carre_overview_2009,
+	address = {Paris, France},
+	title = {Overview on the {French} nuclear fuel cycle strategy and transition scenario studies},
+	url = {https://www.researchgate.net/profile/Frank_Carre/publication/273751217_Overview_on_the_French_Nuclear_Fuel_Cycle_Strategy_and_Transition_Scenario_Studies/links/55f6ace108ae07629dbae8ea.pdf},
+	abstract = {This paper gives an overview on the French nuclear fuel cycle strategy and on the scenario studies performed to
+describe the transition from Gen II to Gen IV systems. It also gives a presentation of the R\&D performed in France and in
+collaboration with international initiatives on advanced fuel cycle associated with Gen IV systems},
+	booktitle = {Proceedings of {GLOBAL}},
+	author = {Carre, Frank and Delbecq, Jean-Michel},
+	year = {2009},
+	file = {[PDF] researchgate.net:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/A2XM22QS/Carr{\'e} and Delbecq - 2009 - Overview on the French nuclear fuel cycle strategy.pdf:application/pdf}
 }
 
 @article{madic_futuristic_2007,
@@ -275,163 +356,75 @@ storage centre (centre de stockage de l’Aube – CSA)},
 	year = {2007},
 	keywords = {Actinide alloys and compounds},
 	pages = {23--27},
-	file = {ScienceDirect Snapshot:/home/dkadkf/Zotero/storage/QNKQI4NX/S0925838807012029.html:text/html}
+	file = {ScienceDirect Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/QNKQI4NX/S0925838807012029.html:text/html}
 }
 
-@inproceedings{carre_overview_2009,
-	address = {Paris, France},
-	title = {Overview on the {French} nuclear fuel cycle strategy and transition scenario studies},
-	url = {https://www.researchgate.net/profile/Frank_Carre/publication/273751217_Overview_on_the_French_Nuclear_Fuel_Cycle_Strategy_and_Transition_Scenario_Studies/links/55f6ace108ae07629dbae8ea.pdf},
-	abstract = {This paper gives an overview on the French nuclear fuel cycle strategy and on the scenario studies performed to
-describe the transition from Gen II to Gen IV systems. It also gives a presentation of the R\&D performed in France and in
-collaboration with international initiatives on advanced fuel cycle associated with Gen IV systems},
-	booktitle = {Proceedings of {GLOBAL}},
-	author = {Carre, Frank and Delbecq, Jean-Michel},
-	year = {2009},
-	file = {[PDF] researchgate.net:/home/dkadkf/Zotero/storage/A2XM22QS/Carré and Delbecq - 2009 - Overview on the French nuclear fuel cycle strategy.pdf:application/pdf}
+@article{coquelet-pascal_comparison_nodate,
+	title = {Comparison of different scenarios for the deployment of fast reactors in {France}. {Results} obtained with {COSI}},
+	url = {http://inis.iaea.org/Search/search.aspx?orig_q=RN:44008962},
+	language = {English},
+	urldate = {2017-06-17},
+	author = {Coquelet-Pascal, Christine and Meyer, Maryan and Girieud, Richard},
+	file = {Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/USKER87I/search.html:text/html}
 }
 
-@article{salvatores_nuclear_2005,
-	title = {Nuclear fuel cycle strategies including {Partitioning} and {Transmutation}},
-	volume = {235},
-	issn = {0029-5493},
-	url = {http://www.sciencedirect.com/science/article/pii/S0029549304003759},
-	doi = {10.1016/j.nucengdes.2004.10.009},
-	abstract = {The widespread concern about radioactive waste management has promoted interest during the last decade for the potential role of Partitioning and Transmutation strategies, in order to alleviate the burden on future deep geological repositories. The physics of transmutation allows to point-out preferential approaches, e.g., based on the use of a fast neutron spectrum. The practical implementation of Partitioning and Transmutation implies the development of sophisticated technologies and can be more realistic if seen in a regional context. Some examples will be given to illustrate the “regional” approach, and some considerations will be made on the use of Accelerator Driven Systems (ADS), in the frame of a progressive strategy from present nuclear power fleets to future systems, as studied, e.g., in the frame of the GENERATION-IV initiative.},
-	number = {7},
-	journal = {Nuclear Engineering and Design},
-	author = {Salvatores, M.},
-	month = mar,
-	year = {2005},
-	pages = {805--816},
-	file = {ScienceDirect Snapshot:/home/dkadkf/Zotero/storage/3PMMTCTG/S0029549304003759.html:text/html}
+@article{martinez-val_pateros_2009,
+	title = {{PATEROS} {P}\&{T} {Roadmap} proposal for advanced fuel cycles leading to a sustainable nuclear energy: syntheses report},
+	shorttitle = {{PATEROS} {P}\&{T} {Roadmap} proposal for advanced fuel cycles leading to a sustainable nuclear energy},
+	author = {Martinez-Val, J.},
+	year = {2009}
 }
 
-@article{varaine_pre-conceptual_2012,
-	title = {Pre-conceptual design study of {ASTRID} core},
-	url = {https://www.researchgate.net/profile/Frederic_Varaine/publication/282657288_Pre-conceptual_design_study_of_ASTRID_core/links/56166d1908ae37cfe4090bb7.pdf},
-	abstract = {In the framework of the ASTRID project at CEA, core design studies are performed at CEA with the AREVA and EDF support. At the stage of the project, pre-conceptual design studies are conducted in accordance with GEN IV reactors criteria, in particularly for safety improvements. An improved safety for a sodium cooled reactor requires revisiting many aspects of the design and is a rather lengthy process in current design approach. Two types of cores are under evaluation, one classical derivated from the SFR V2B and one more challenging called CFV (low void effect core) with a large gain on the sodium void effect. The SFR V2b core have the following specifications : a very low burn-up reactivity swing (due to a small cycle reactivity loss) and a reduced sodium void effect with regard to past designs such as the EFR (around 2\$ minus). Its performances are an average burn-up of 100 GWd/t, and an internal conversion ratio equal to one given a very good behavior of this core during a control rod withdrawal transient). The CFV with its specific design offers a negative sodium void worth while maintaining core performances. In accordance of ASTRID needs for demonstration those cores are 1500 MWth power (600 MWe). This paper will focus on the CFV pre-conceptual design of the core and S/A, and the performances in terms of safety will be evaluated on different transient scenario like ULOF, in order to assess its intrinsic behavior compared to a more classical design like V2B core. The gap in term of margin to a severe accident due to a loss of flow initiator underlines the potential capability of this type of core to enhance prevention of severe accident in accordance to safety demonstration. 
-
-Pre-conceptual design study of ASTRID core (PDF Download Available). Available from: https://www.researchgate.net/publication/282657288\_Pre-conceptual\_design\_study\_of\_ASTRID\_core [accessed Aug 31, 2017].},
-	urldate = {2017-05-19},
-	author = {Varaine, Frederic and Chenaud, Marie-Sophie and Marsault, Philippe and Bernardin, Bruno and Conti, Alain and Sciora, Pierre and Venard, Christophe and Fontaine, Bruno and Martin, Laurent and Mignot, Gerard},
-	month = jun,
-	year = {2012},
-	file = {[PDF] researchgate.net:/home/dkadkf/Zotero/storage/2B4SNXP4/MARSAULT–Marie-Sophie et al. - Pre-conceptual design study of ASTRID core.pdf:application/pdf}
+@techreport{piet_implications_2010,
+	title = {Implications of {Fast} {Reactor} {Transuranic} {Conversion} {Ratio}},
+	url = {https://www.researchgate.net/profile/Steve_Piet/publication/255218036_Implications_of_Fast_Reactor_Transuranic_Conversion_Ratio/links/54f87b470cf2ccffe9df3b55/Implications-of-Fast-Reactor-Transuranic-Conversion-Ratio.pdf},
+	institution = {Idaho National Laboratory (INL)},
+	author = {Piet, Steven J. and Hoffman, Edward A. and Bays, Samuel E.},
+	year = {2010},
+	file = {[PDF] researchgate.net:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/WSSD6JHQ/Piet et al. - 2010 - Implications of Fast Reactor Transuranic Conversio.pdf:application/pdf}
 }
 
-@book{hatch_politics_2015,
-	title = {Politics and {Nuclear} {Power}: {Energy} {Policy} in {Western} {Europe}},
-	isbn = {978-0-8131-6307-9},
-	shorttitle = {Politics and {Nuclear} {Power}},
-	abstract = {With the dramatic changes OPEC precipitated in the structure of world energy markets during the 1970s, energy became a central concern to policymakers throughout the industrialized West. This book ex-amines the responses of public officials in three leading European nations -- the Federal Republic of Germany, France, and the Netherlands -- to the energy crisis. As the study shows, the proposed energy programs in the three countries shared remarkable similarities; yet the policy outcomes were very different. To explain why, Michael T. Hatch goes beyond the specific content of government energy policy to include an analysis of the policymaking process itself.At the heart of the study is an exploration of the various dimensions of nuclear policy in West Germany. The political consensus on nuclear power that prevailed in the initial years following the energy crisis disintegrated as antinuclear "citizens' initiatives," the courts, and trade unions, as well as the traditional political parties, entered the policymaking process. Subsequent government efforts to resolve the political stalemate over nuclear power foundered in a morass of domestic electoral politics and an international debate over nuclear proliferation.Extending the analysis to comparisons with French and Dutch nuclear strategies, Hatch argues that the critical factor in determining nuclear policy was the manner in which the political system structured the nuclear debate. In contrast to West Germany, where the electoral and parliamentary systems enhanced the influence of the antinuclear "Greens," the electoral system and constellation of political parties in France served to dissipate the influence of the antinuclear forces. Thus in France the nuclear program en-countered few impediments. In the Netherlands, as in West Germany, government policy was paralyzed in the face of antinuclear sentiment across a broad spectrum of Dutch society.Hatch has provided here not only a useful examination of the development of energy policy in western Europe but also a case study of the close interplay between policy and politics.},
-	language = {en},
-	publisher = {University Press of Kentucky},
-	author = {Hatch, Michael T.},
-	month = jan,
-	year = {2015},
-	note = {Google-Books-ID: TrwfBgAAQBAJ},
-	keywords = {History / Europe / Western, Political Science / Public Policy / Science \& Technology Policy, Technology \& Engineering / Power Resources / Nuclear}
-}
-
-@article{sutharshan_ap1000tm_2011,
-	series = {Asian {Nuclear} {Prospects} 2010},
-	title = {The {AP}1000TM {Reactor}: {Passive} {Safety} and {Modular} {Design}},
-	volume = {7},
-	issn = {1876-6102},
-	shorttitle = {The {AP}1000TM {Reactor}},
-	url = {http://www.sciencedirect.com/science/article/pii/S1876610211015475},
-	doi = {10.1016/j.egypro.2011.06.038},
-	abstract = {Our world is ever growing, there will be higher demands on electricity, and fossil fuels cannot satisfy this demand without further harming the environment. Likewise, renewable energy sources such as solar and winds are still in their infancy and, when used alone, are not realistic solutions to meet this demand. Westinghouse Electric Company is ready to address higher electricity demand with the only Generation III+reactor to receive Design Certification from the United States Nuclear Regulatory Commission, the AP1000™ pressurized water reactor (PWR). Westinghouse Electric Company once again sets a new industry standard with the AP1000™ reactor. The AP1000™ is a two-loopPressurized Water Reactor (PWR) with passive safety features and extensive plant simplifications that enhance its construction, operation, maintenance and safety. The paper discusses the unique design features of AP 1000.},
-	urldate = {2017-05-12},
-	journal = {Energy Procedia},
-	author = {Sutharshan, Balendra and Mutyala, Meena and Vijuk, Ronald P and Mishra, Alok},
-	month = jan,
-	year = {2011},
-	keywords = {core operating parameters, Generation III+ reactor, modular design, passive safety, probabilistic risk assessment, PWR},
-	pages = {293--302},
-	file = {ScienceDirect Full Text PDF:/home/dkadkf/Zotero/storage/2D66N8K4/Sutharshan et al. - 2011 - The AP1000TM Reactor Passive Safety and Modular D.pdf:application/pdf;ScienceDirect Snapshot:/home/dkadkf/Zotero/storage/E87IC8RM/S1876610211015475.html:text/html}
-}
-
-@article{lamarsh_introduction_1983,
-	title = {Introduction to nuclear engineering},
-	url = {https://inis.iaea.org/search/search.aspx?orig_q=RN:17073185},
-	urldate = {2017-05-11},
-	author = {Lamarsh, John R.},
-	year = {1983},
-	file = {Snapshot:/home/dkadkf/Zotero/storage/SZH27EZ6/search.html:text/html}
-}
-
-@article{huff_fundamental_2016,
-	title = {Fundamental concepts in the {Cyclus} nuclear fuel cycle simulation framework},
-	volume = {94},
-	issn = {0965-9978},
-	url = {http://www.sciencedirect.com/science/article/pii/S0965997816300229},
-	doi = {10.1016/j.advengsoft.2016.01.014},
-	abstract = {As nuclear power expands, technical, economic, political, and environmental analyses of nuclear fuel cycles by simulators increase in importance. To date, however, current tools are often fleet-based rather than discrete and restrictively licensed rather than open source. Each of these choices presents a challenge to modeling fidelity, generality, efficiency, robustness, and scientific transparency. The Cyclus nuclear fuel cycle simulator framework and its modeling ecosystem incorporate modern insights from simulation science and software architecture to solve these problems so that challenges in nuclear fuel cycle analysis can be better addressed. A summary of the Cyclus fuel cycle simulator framework and its modeling ecosystem are presented. Additionally, the implementation of each is discussed in the context of motivating challenges in nuclear fuel cycle simulation. Finally, the current capabilities of Cyclus are demonstrated for both open and closed fuel cycles.},
-	urldate = {2016-02-12},
-	journal = {Advances in Engineering Software},
-	author = {Huff, Kathryn D. and Gidden, Matthew J. and Carlsen, Robert W. and Flanagan, Robert R. and McGarry, Meghan B. and Opotowsky, Arrielle C. and Schneider, Erich A. and Scopatz, Anthony M. and Wilson, Paul P. H.},
-	month = apr,
-	year = {2016},
-	keywords = {Nuclear fuel cycle, agent based modeling, Computer Science - Computational Engineering, Finance, and Science, Computer Science - Mathematical Software, Computer Science - Multiagent Systems, Computer Science - Software Engineering, D.2.13, D.2.4, I.6.7, I.6.8, Nuclear Engineering, Object orientation, Systems analysis, Nuclear Fuel Cycle, Simulation, Finance, and Science, Computer Science - Computational Engineering, Systems Analysis},
-	pages = {46--59},
-	annote = {arXiv: 1509.03604},
-	file = {arXiv\:1509.03604 PDF:/home/dkadkf/Zotero/storage/F9KVM9DZ/Huff et al. - 2015 - Fundamental Concepts in the Cyclus Fuel Cycle Simu.pdf:application/pdf;arXiv\:1509.03604 PDF:/home/dkadkf/Zotero/storage/4FI3T63Q/Huff et al. - 2015 - Fundamental Concepts in the Cyclus Fuel Cycle Simu.pdf:application/pdf;arXiv.org Snapshot:/home/dkadkf/Zotero/storage/HXSDS7VW/1509.html:text/html;arXiv.org Snapshot:/home/dkadkf/Zotero/storage/WQVTXAN2/1509.html:text/html;fundamentals.pdf:/home/dkadkf/Zotero/storage/C6G4NQJH/fundamentals.pdf:application/pdf;fundamentals.pdf:/home/dkadkf/Zotero/storage/BRJECDWC/fundamentals.pdf:application/pdf;ScienceDirect Full Text PDF:/home/dkadkf/Zotero/storage/E7DK64AA/Huff et al. - 2016 - Fundamental concepts in the Cyclus nuclear fuel cy.pdf:application/pdf;ScienceDirect Snapshot:/home/dkadkf/Zotero/storage/JCCZAZB3/S0965997816300229.html:text/html;ScienceDirect Snapshot:/home/dkadkf/Zotero/storage/63CHUQ54/login.html:text/html;ScienceDirect Snapshot:/home/dkadkf/Zotero/storage/EVBNKXMA/S0965997816300229.html:text/html}
-}
-
-@article{brown_identification_2016,
-	title = {Identification of fuel cycle simulator functionalities for analysis of transition to a new fuel cycle},
-	volume = {96},
-	issn = {0306-4549},
-	url = {http://www.sciencedirect.com/science/article/pii/S0306454916303383},
-	doi = {10.1016/j.anucene.2016.05.027},
-	abstract = {Dynamic fuel cycle simulation tools are intended to model holistic transient nuclear fuel cycle scenarios. As with all simulation tools, fuel cycle simulators require verification through unit tests, benchmark cases, and integral tests. Model validation is a vital aspect, as well. Although comparative studies have been performed, there is no comprehensive unit test and benchmark library for fuel cycle simulator tools. The objective of this paper is to identify some of the “must test” functionalities of a fuel cycle simulator tool within the context of specific problems of interest to the Fuel Cycle Options Campaign within the U.S. Department of Energy’s Office of Nuclear Energy (DOE-NE). This paper identifies the features needed to cover the range of promising fuel cycle options identified in the DOE-NE Fuel Cycle Evaluation and Screening and categorizes these features to facilitate prioritization. Features are categorized as essential functions, integrating features, and exemplary capabilities. A library of unit tests applicable to each of the essential functions should be developed as future work. An international dialog on the functionalities and standard test methods for fuel cycle simulator tools is encouraged.},
-	urldate = {2016-09-23},
-	journal = {Annals of Nuclear Energy},
-	author = {Brown, Nicholas R. and Carlsen, Brett W. and Dixon, Brent W. and Feng, Bo and Greenberg, Harris R. and Hays, Ross D. and Passerini, Stefano and Todosow, Michael and Worrall, Andrew},
+@phdthesis{fabbris_optimisation_2014,
+	type = {phdthesis},
+	title = {Optimisation multi-physique et multi-crit{\`e}re des coeurs de {RNR}-{Na} : application au concept {CFV}},
+	shorttitle = {Optimisation multi-physique et multi-crit{\`e}re des coeurs de {RNR}-{Na}},
+	url = {https://tel.archives-ouvertes.fr/tel-01133491/document},
+	abstract = {La conception du coeur d{\textquoteright}un r{\'e}acteur nucl{\'e}aire est fortement multidisciplinaire (neutronique, thermo-hydraulique, thermom{\'e}canique du combustible, physique du cycle, etc.). Le probl{\`e}me est aussi de type multi-objectif (plusieurs performances) {\`a} grand nombre de dimensions (plusieurs dizaines de param{\`e}tres de conception).Les codes de calculs d{\'e}terministes utilis{\'e}s traditionnellement pour la caract{\'e}risation des coeurs demandant d{\textquoteright}importantes ressources informatiques, l{\textquoteright}approche de conception classique rend difficile l{\textquoteright}exploration et l{\textquoteright}optimisation de nouveaux concepts innovants. Afin de pallier ces difficult{\'e}s, une nouvelle m{\'e}thodologie a {\'e}t{\'e} d{\'e}velopp{\'e}e lors de ces travaux de th{\`e}se. Ces travaux sont bas{\'e}s sur la mise en oeuvre et la validation de sch{\'e}mas de calculs neutronique et thermo-hydraulique pour disposer d{\textquoteright}un outil de caract{\'e}risation d{\textquoteright}un coeur de r{\'e}acteur {\`a} neutrons rapides {\`a} caloporteur sodium tant du point de vue des performances neutroniques que de son comportement en transitoires accidentels.La m{\'e}thodologie mise en oeuvre s{\textquoteright}appuie sur la construction de mod{\`e}les de substitution (ou m{\'e}tamod{\`e}les) aptes {\`a} remplacer la cha{\^i}ne de calcul neutronique et thermo-hydraulique. Des m{\'e}thodes math{\'e}matiques avanc{\'e}es pour la planification d{\textquoteright}exp{\'e}riences, la construction et la validation des m{\'e}tamod{\`e}les permettent de remplacer cette cha{\^i}ne de calcul par des mod{\`e}les de r{\'e}gression au pouvoir de pr{\'e}diction {\'e}lev{\'e}.La m{\'e}thode est appliqu{\'e}e {\`a} un concept innovant de coeur {\`a} Faible coefficient de Vidange sur un tr{\`e}s large domaine d{\textquoteright}{\'e}tude, et {\`a} son comportement lors de transitoires thermo-hydrauliques non prot{\'e}g{\'e}s pouvant amener {\`a} des situations incidentelles, voire accidentelles. Des analyses globales de sensibilit{\'e} permettent d{\textquoteright}identifier les param{\`e}tres de conception influents sur la conception du coeur et son comportement en transitoire. Des optimisations multicrit{\`e}res conduisent {\`a} des nouvelles configurations dont les performances sont parfois significativement am{\'e}lior{\'e}es. La validation des r{\'e}sultats produits au cours de ces travaux de th{\`e}se d{\'e}montre la pertinence de la m{\'e}thode au stade de la pr{\'e}conception d{\textquoteright}un coeur de r{\'e}acteur {\`a} neutrons rapides refroidi au sodium.},
+	language = {fr},
+	urldate = {2017-07-21},
+	school = {Universit{\'e} de Grenoble},
+	author = {Fabbris, Olivier},
 	month = oct,
-	year = {2016},
-	keywords = {Fuel cycle simulator, Transition analysis, Unit tests},
-	pages = {88--95},
-	file = {ScienceDirect Full Text PDF:/home/dkadkf/Zotero/storage/9H5GZ7QA/Brown et al. - 2016 - Identification of fuel cycle simulator functionali.pdf:application/pdf;ScienceDirect Snapshot:/home/dkadkf/Zotero/storage/Z6WQH4Q4/S0306454916303383.html:text/html;ScienceDirect Snapshot:/home/dkadkf/Zotero/storage/NFQC7CXG/S0306454916303383.html:text/html}
+	year = {2014},
+	file = {Full Text PDF:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/AI9FANBF/Fabbris - 2014 - Optimisation multi-physique et multi-crit{\`e}re des c.pdf:application/pdf;Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/54B5PP4P/tel-01133491.html:text/html}
 }
 
 @article{freynet_multiobjective_2016-1,
 	title = {Multiobjective optimization for nuclear fleet evolution scenarios using {COSI}},
 	volume = {2},
 	url = {http://epjn.epj.org/articles/epjn/abs/2016/01/epjn150066/epjn150066.html},
-	urldate = {2017-02-17},
 	journal = {EPJ Nuclear Sciences \& Technologies},
 	author = {Freynet, David and Coquelet-Pascal, Christine and Eschbach, Romain and Krivtchik, Guillaume and Merle-Lucotte, Elsa},
 	year = {2016},
 	pages = {9},
-	file = {[HTML] epj-n.org:/home/dkadkf/Zotero/storage/AVP329PE/epjn150066.html:text/html;Snapshot:/home/dkadkf/Zotero/storage/HIBGZJTC/epjn150066.html:text/html}
+	file = {epjn150066.pdf:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/HA6HH8VJ/epjn150066.pdf:application/pdf;[HTML] epj-n.org:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/ZHNXV2WH/epjn150066.html:text/html;Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/8URTHTBQ/epjn150066.html:text/html}
 }
 
-@article{martin_symbiotic_2017,
-	title = {Symbiotic equilibrium between {Sodium} {Fast} {Reactors} and {Pressurized} {Water} {Reactors} supplied with {MOX} fuel},
-	volume = {103},
-	issn = {0306-4549},
-	url = {http://www.sciencedirect.com/science/article/pii/S0306454916308076},
-	doi = {10.1016/j.anucene.2017.01.041},
-	abstract = {The symbiotic equilibrium between 1.51 GWe breeder SFR (Sodium Fast Reactors) and 1.6 GWe EPR™ (European Pressurized water Reactors) is studied. EPR™ are only supplied with MOX (Mixed OXide) fuel to avoid the use of natural uranium. The equilibrium is studied by considering the flows of plutonium. Its isotopic composition is here described by a single real number referred to as the Pu grade. Plutonium flows through both reactor types are characterized by using linear functions of the Pu grade in new fuels. These functions have been determined by fitting data from a former scenario study carried out with the COSI6 simulation software.
-Two different reprocessing strategies are considered. With joint reprocessing of all spent fuels, total and fissile plutonium flows balance for a unique fraction x of EPR™ in the fleet, equal to 0.2547. This x value is consistent with the results reported in the former scenario study mentioned above. When EPR™ spent fuels are used in priority to supply SFR (distinct reprocessing), x reaches 0.2582 at most. COSI6 simulations have been performed to further assess these results. The EPR™ fraction in the fleet at symbiotic equilibrium barely depends on the applied reprocessing strategy, so that the more flexible joint reprocessing constitutes the reference option in that case.},
-	urldate = {2017-02-16},
-	journal = {Annals of Nuclear Energy},
-	author = {Martin, G. and Coquelet-Pascal, C.},
+@article{gabrielli_astrid-like_2015,
+	series = {The {Fourth} {International} {Symposium} on {Innovative} {Nuclear} {Energy} {Systems}, {INES}-4},
+	title = {{ASTRID}-like {Fast} {Reactor} {Cores} for {Burning} {Plutonium} and {Minor} {Actinides}},
+	volume = {71},
+	issn = {1876-6102},
+	url = {http://www.sciencedirect.com/science/article/pii/S1876610214026927},
+	doi = {10.1016/j.egypro.2014.11.863},
+	abstract = {A reduction of nuclear waste by transmutation of trans-uranium elements (TRUs), such as Pu and Minor Actinides (MAs) contained in Spent Nuclear Fuel (SNF), is a goal for future reactors. In general, countries with on-going nuclear scenarios would profit from MA mass stabilization, while transmutation of Pu and MAs from SNF could be desired in countries in nuclear phase-out. Both missions can be accomplished by employing fast reactors loaded with fuels containing different amounts of Pu and MAs in a closed (or partially closed) fuel cycle. In this paper, two 1200 MWth sodium-cooled fast reactor cores, based on the French ASTRID design, are proposed for burning TRUs (phase-out option) or only MAs (on-going option). Main attention is focused on the safety and on the transmutation performance. The coolant void effect, in the region including the core and the plenum above and the Doppler constant of both systems are negative also with irradiated fuel. The conversion ratios (CR) of the Pu and MA burners are in the ranges from 0.6 to 0.7 and from 0.5 to 0.6, respectively. These results show a large safety and transmutation potential of ASTRID type reactors.},
+	journal = {Energy Procedia},
+	author = {Gabrielli, Fabrizio and Rineiski, Andrei and Vezzoni, Barbara and Maschek, Werner and Fazio, Concetta and Salvatores, Massimo},
 	month = may,
-	year = {2017},
-	keywords = {Nuclear energy, SFR, FAST REACTORS, plutonium, EPR™, Fuel reprocessing, Symbiotic nuclear systems, Thermal reactors},
-	pages = {356--362},
-	file = {ScienceDirect Full Text PDF:/home/dkadkf/Zotero/storage/4D8VC2KI/Martin and Coquelet-Pascal - 2017 - Symbiotic equilibrium between Sodium Fast Reactors.pdf:application/pdf;ScienceDirect Snapshot:/home/dkadkf/Zotero/storage/VPCQBPZW/S0306454916308076.html:text/html}
-}
-
-@techreport{wilson_adoption_2009,
-	title = {The {Adoption} of {Advanced} {Fuel} {Cycle} {Technology} {Under} a {Single} {Repository} {Policy}},
-	institution = {University of Wisconsin -- Madison},
-	author = {Wilson, P.},
-	year = {2009}
+	year = {2015},
+	keywords = {Nuclear fuel cycle, Nuclear reactor safety, Sodium fast reactors, Transmutation},
+	pages = {130--139},
+	file = {ScienceDirect Full Text PDF:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/2APV2MPJ/Gabrielli et al. - 2015 - ASTRID-like Fast Reactor Cores for Burning Plutoni.pdf:application/pdf;ScienceDirect Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/I78CKW34/S1876610214026927.html:text/html}
 }
 
 @misc{bae_arfc/transition-scenarios:_2017,
@@ -445,7 +438,7 @@ Two different reprocessing strategies are considered. With joint reprocessing of
 	month = aug,
 	year = {2017},
 	note = {DOI: 10.5281/zenodo.858671},
-	file = {Zenodo Snapshot:/home/dkadkf/Zotero/storage/B8JXTTQ8/858671.html:text/html}
+	file = {Zenodo Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/B8JXTTQ8/858671.html:text/html}
 }
 
 @book{iaea_nuclear_2017,
@@ -460,7 +453,7 @@ Two different reprocessing strategies are considered. With joint reprocessing of
 	publisher = {IAEA},
 	author = {IAEA, PRIS},
 	year = {2017},
-	file = {Full Text PDF:/home/dkadkf/Zotero/storage/XRPA6LRK/IAEA - 2017 - Nuclear Power Reactors in the World.pdf:application/pdf;Snapshot:/home/dkadkf/Zotero/storage/N7TTNBDG/Nuclear-Power-Reactors-in-the-World-2017-Edition.html:text/html}
+	file = {Full Text PDF:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/XRPA6LRK/IAEA - 2017 - Nuclear Power Reactors in the World.pdf:application/pdf;Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/N7TTNBDG/Nuclear-Power-Reactors-in-the-World-2017-Edition.html:text/html}
 }
 
 @inproceedings{gidden_agent-based_2015,
@@ -468,11 +461,24 @@ Two different reprocessing strategies are considered. With joint reprocessing of
 	title = {Agent-based dynamic resource exchange in {CYCLUS}},
 	url = {http://inis.iaea.org/Search/search.aspx?orig_q=RN:47042686},
 	doi = {10.11484/jaea-conf-2014-003},
-	abstract = {A novel methodology for modeling the dynamic exchange of resources among actors in the CYCLUS fuel cycle simulator is described. The methodology is comprised of an information gathering step, a bipartite-graph-based supply-demand matching step, and a trade execution step. Its implementation in CYCLUS allows the simulator to model generic fuel cycles, i.e., those in which the types of facilities and possible resource flows is not known a priori. The flow of resources at each time step is algorithmically determined based on facilities’ resource flow preferences. The dynamicsim of both the preference-based flows and quantity and quality constraints on those flows are demonstrated via two simple scenarios. The first scenario exemplifies situations in which actors’ preferences change over time and the second typifies situations in which quality-based constraints limit resource flow. This generic capability provides a sufficient framework and basis for the CYCLUS simulation engine to model complex, advanced fuel cycles. (author)},
+	abstract = {A novel methodology for modeling the dynamic exchange of resources among actors in the CYCLUS fuel cycle simulator is described. The methodology is comprised of an information gathering step, a bipartite-graph-based supply-demand matching step, and a trade execution step. Its implementation in CYCLUS allows the simulator to model generic fuel cycles, i.e., those in which the types of facilities and possible resource flows is not known a priori. The flow of resources at each time step is algorithmically determined based on facilities{\textquoteright} resource flow preferences. The dynamicsim of both the preference-based flows and quantity and quality constraints on those flows are demonstrated via two simple scenarios. The first scenario exemplifies situations in which actors{\textquoteright} preferences change over time and the second typifies situations in which quality-based constraints limit resource flow. This generic capability provides a sufficient framework and basis for the CYCLUS simulation engine to model complex, advanced fuel cycles. (author)},
 	language = {English},
 	urldate = {2017-09-14},
 	publisher = {JAEA},
 	author = {Gidden, Matthew and Carlsen, Robert and Opotowsky, Arrielle and Rakhimov, Olzhas and Scopatz, Anthony M. and Wilson, Paul P. H.},
 	year = {2015},
-	file = {Snapshot:/home/dkadkf/Zotero/storage/4VK7Z6KI/search.html:text/html}
+	file = {Snapshot:/Users/khuff/Library/Application Support/Zotero/Profiles/lvoutoj9.default/zotero/storage/4VK7Z6KI/search.html:text/html}
+}
+
+@book{duderstadt_nuclear_1976,
+	address = {New York},
+	edition = {1 edition},
+	title = {Nuclear {Reactor} {Analysis}},
+	isbn = {978-0-471-22363-4},
+	abstract = {Classic textbook for an introductory course in nuclear reactor analysis that introduces the nuclear engineering student to the basic scientific principles of nuclear fission chain reactions and lays a foundation for the subsequent application of these principles to the nuclear design and analysis of reactor cores. This text introduces the student to the fundamental principles governing nuclear fission chain reactions in a manner that renders the transition to practical nuclear reactor design methods most natural. The authors stress throughout the very close interplay between the nuclear analysis of a reactor core and those nonnuclear aspects of core analysis, such as thermal-hydraulics or materials studies, which play a major role in determining a reactor design.},
+	language = {English},
+	publisher = {Wiley},
+	author = {Duderstadt, James J. and Hamilton, Louis J.},
+	month = jan,
+	year = {1976}
 }

--- a/introduction.tex
+++ b/introduction.tex
@@ -113,7 +113,7 @@ which lists the individual reactor units as agents.
 
 Projections of future reactor deployment in this simulation are based on assessment of analyses
 from references such as \gls{PRIS} for reactors planned for construction \cite{iaea_nuclear_2017},
-the World Nuclear Association \cite{Worldd_nuclear_association_nuclear_2017}, and works on the future of nuclear power in a global \cite{joskow_future_2012} and European context \cite{hatch_politics_2015}. 
+the World Nuclear Association \cite{world_nuclear_association_nuclear_2017}, and works on the future of nuclear power in a global \cite{joskow_future_2012} and European context \cite{hatch_politics_2015}. 
 The projections extend to 2050 at the latest. This allows the simulation to take place from
 1970 to 2050. Later sections explain, in detail, the specific plans for each \gls{EU} nation.
 

--- a/scenario_specifications.tex
+++ b/scenario_specifications.tex
@@ -79,7 +79,7 @@ historical refueling outage. The specifications are defined in
                 Rated Power [MWe] & 1000 & 1000 & 600\\
                 Assembly mass [kg] & 523.4 & 180 & -- \\
                 Batch mass [kg] & -- & -- & 5,568\\
-                Discharge Burnup [GWd/tHM] & 51 & 51 & --\\
+                Discharge Burnup [GWd/tHM] & 51 & 51 & 105 \\
                 Assemblies per core & 193  & 764 & -- \\
                 Batches per core & 3 & 3 & 4\\
                 Fuel & \gls{UOX} or \gls{MOX} & \gls{UOX} & \gls{MOX} \\

--- a/scenario_specifications.tex
+++ b/scenario_specifications.tex
@@ -79,7 +79,7 @@ historical refueling outage. The specifications are defined in
                 Rated Power [MWe] & 1000 & 1000 & 600\\
                 Assembly mass [kg] & 523.4 & 180 & -- \\
                 Batch mass [kg] & -- & -- & 5,568\\
-                Discharge Burnup [GWd/tHM] & 51 & 51 & \\
+                Discharge Burnup [GWd/tHM] & 51 & 51 & --\\
                 Assemblies per core & 193  & 764 & -- \\
                 Batches per core & 3 & 3 & 4\\
                 Fuel & \gls{UOX} or \gls{MOX} & \gls{UOX} & \gls{MOX} \\

--- a/scenario_specifications.tex
+++ b/scenario_specifications.tex
@@ -64,47 +64,39 @@ After each 18 month cycle, one-third of the
 core (77 assemblies) discharges. Refueling
 is assumed to take 2 months to complete, during which the reactor
 is shut down. This value is acquired by averaging the 
-historical refueling outage. The specifications are defined in \cref{tab:lwr}.
-
-For the \gls{SFR}, the specifications are defined in \cref{tab:sfr}.
+historical refueling outage. The specifications are defined in 
+\Cref{tab:reactor-specs} details the reactor specifications in this simulation.
 
 \begin{table}[h]
 	\centering
-	\begin{tabularx}{\textwidth}{bcc}
+	\begin{tabularx}{\textwidth}{blll}
 		\hline
-		\textbf{Specification} & \textbf{\gls{PWR}} & \textbf{\gls{BWR}} \\
+		\textbf{Specification} & \textbf{\gls{PWR}} & \textbf{\gls{BWR}} & \textbf{\gls{SFR}}\\
 		\hline
-		Lifetime & \multicolumn{2}{c}{60 years unless shutdown prematurely} \\
-		PWR Cycle Time & \multicolumn{2}{c}{18 months}\\ 
-		PWR Refueling Outage & \multicolumn{2}{c}{2 months} \\
-		Fuel Mass per Assembly & 523.4 kg & 180 kg \\
-		Burnup & \multicolumn{2}{c}{51 GWd/tons }\\
-		Assembly per Core & 193 for 1,000 MWe & 764 for 1,000 MWe\\
-		Assembly per Batch & \multicolumn{2}{c}{1/3 of the core }\\
-		Fuel & \gls{UOX}, \gls{MOX} & \gls{UOX} \\
+                Lifetime [y] & 60 & 60 & 80 \\
+                Cycle Time [mos.]& 18 & 18 & 12\\ 
+                Refueling Outage [mos.]& 2 & 2  & 2\\
+                Rated Power [MWe] & 1000 & 1000 & 600\\
+                Assembly mass [kg] & 523.4 & 180 & -- \\
+                Batch mass [kg] & -- & -- & 5,568\\
+                Discharge Burnup [GWd/tHM] & 51 & 51 & \\
+                Assemblies per core & 193  & 764 & -- \\
+                Batches per core & 3 & 3 & 4\\
+                Fuel & \gls{UOX} or \gls{MOX} & \gls{UOX} & \gls{MOX} \\
 		\hline
 	\end{tabularx}
-	\caption {\gls{LWR} Specifications}
-	\label{tab:lwr}
+        \caption {\gls{LWR} Specifications are derived from 
+                \cite{duderstadt_nuclear_1976} while \gls{ASTRID} \gls{SFR} 
+                specifications were sourced from 
+        \cite{varaine_pre-conceptual_2012}.}
+	\label{tab:reactor-specs}
 	\end{table}
+
+        \footnotetext{The simulated reactor lifetime reaches the licensed lifetime unless 
+        the reactor is shut down prematurely.} 
+        \footnotetext{Number of assemblies and corresponding \gls{LWR} core 
+        masses are reported for a 1000MWe core. Reactors with different core  
+        powers are modeled with a linear mass assumption.}
 	
-\begin{table}[h]
-	\centering
-	\begin{tabularx}{\textwidth}{bb}
-		\hline
-		\textbf{Specification} &\textbf{ Value} \\
-		\hline
-		SFR Cycle Time & 12 months \\ 
-		SFR Refueling Outage & 2 months \\
-		Fuel Mass per Batch & 5,568 kg \\
-		Batch per Core & 4 \\
-		Power Output & 600 MWe \\
-		Lifetime & 80 years \\
-		Fuel & {\small \gls{MOX} (78\% Tailings, 22\% Separated Pu)}\\
-		\hline
-	\end{tabularx}
-	\caption {\gls{SFR} ASTRID Specifications \cite{varaine_pre-conceptual_2012}}
-	\label{tab:sfr}
-\end{table}
 \FloatBarrier
 


### PR DESCRIPTION
This PR handles issue #45.

- fixes alignment to be more readable
- condenses units into row definitions.
- elaborates on sources of information in the caption.
- the pwr table and the sfr table could be combined... how many batches per core did you assume for SFRs? Just one, probably... I've left some dashes where more information should be added.
- much of this information has come from duderstadt, so I added that book to the bibliography.
- the unit for burnup is usually not plural in tons (it's normalized by tons, so the unit is GWd per ton). So... it should be GWd/ton. More specifically, it usu GWd/MTIHM or GWd/tHM.
- There is no reason to state, in the row labels, that you're referring to PWR Cycle time or PWR Refuelling outage. The reactor type is listed in the column label.
- the number of assemblies per batch is not well described as '1/3 of the core'. I think the intention was probably to have a column "batches per core." If that's the case, the value should be 3.
